### PR TITLE
Feat/agent settings

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,3 @@
-
 default['scalyr_agent']['api_key'] = nil
 
 default['scalyr_agent']['scalyr_server'] = nil
@@ -6,5 +5,6 @@ default['scalyr_agent']['scalyr_server'] = nil
 default['scalyr_agent']['hostname'] = nil
 
 default['scalyr_agent']['logs'] = {}
+default['scalyr_agent']['agent_settings'] = {}
 default['scalyr_agent']['server_attributes'] = {}
 default['scalyr_agent']['monitors'] = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,3 +14,5 @@ recipe 'scalyr_agent::start', 'Starts the scalyr agent'
 
 issues_url 'https://github.com/scalyr/scalyr-chef/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/scalyr/scalyr-chef' if respond_to?(:source_url)
+
+chef_version '>= 12.7'

--- a/recipes/update_agent_json.rb
+++ b/recipes/update_agent_json.rb
@@ -1,4 +1,10 @@
+node.default['scalyr_agent']['agent_settings']['scalyr_server'] = node['scalyr_agent']['scalyr_server']
 
 template '/etc/scalyr-agent-2/agent.json' do
   source 'agent.json.erb'
+  variables(lazy do
+    {
+      agent_settings: node['scalyr_agent']['agent_settings'].reject{|k,v| v.nil?}
+    }
+  end)
 end

--- a/templates/agent.json.erb
+++ b/templates/agent.json.erb
@@ -1,16 +1,12 @@
 // Configuration for the Scalyr Agent. For help:
 // 
 // https://www.scalyr.com/help/scalyr-agent-2
-
+// Your API key is configured in:          agent.d/api_key.json
+// Monitors are configured in:             agent.d/monitors.json
+// Logs are configured in:                 agent.d/logs.json
+// Server Attributes are configured in:    agent.d/server_attributes.json
 {
-  // Your API key is configured in:          agent.d/api_key.json
-  // Monitors are configured in:             agent.d/monitors.json
-  // Logs are configured in:                 agent.d/logs.json
-  // Server Attributes are configured in:    agent.d/server_attributes.json
-
-  <% if node['scalyr_agent']['scalyr_server'] -%>
-    scalyr_server: "<%= node['scalyr_agent']['scalyr_server'] %>
-  <% end %>
-
+<% @agent_settings.to_a.each_with_index do |(k, v), idx| -%>
+  <%= k %>: <%= v.inspect %><%= idx != (@agent_settings.size - 1) ? "," : "" %>
+<% end -%>
 }
-


### PR DESCRIPTION
This PR does 2 things:

* Adds open ended support for agent runtime parameters.
* Sets the minimum chef version to 12.7, b/c `apt_update` arrived then (as I discovered, running 12.6).