### PR TITLE
Changed install to handle Amazon Linux 2

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -2,7 +2,7 @@
 case node['platform_family']
   when 'debian'
     include_recipe 'scalyr_agent::install_deb'
-  when 'rhel'
+  when 'amazon', 'rhel'
     include_recipe 'scalyr_agent::install_rpm'
 end
 


### PR DESCRIPTION
According to the [chef.io](https://docs.chef.io/deprecations_ohai_amazon_linux.html) documentation, in Ohai/Chef 13 and later, the Amazon Linux platform family changed to  'amazon'. Changed install.rb to reflect this. This fixed install issue in Amazon Linux 2 instances.