### PR TITLE
Pass package to apt_package individually

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'support@scalyr.com'
 license 'Apache 2.0'
 description 'Installs, configures and runs the scalyr agent'
 long_description 'Installs, configures and runs the scalyr agent'
-version '0.1.2'
+version '0.1.4'
 
 recipe 'scalyr_agent::default', 'Installs, configures and starts the scalyr agent'
 recipe 'scalyr_agent::agent', 'Same as scalyr_agent::default'

--- a/recipes/install_deb.rb
+++ b/recipes/install_deb.rb
@@ -1,6 +1,7 @@
-
-apt_package ['scalyr-repo', 'scalyr-repo-bootstrap'] do
-  action :remove
+%w[scalyr-repo scalyr-repo-bootstrap].each do |pkg|
+  apt_package pkg do
+    action :remove
+  end
 end
 
 remote_file '/tmp/scalyr-repo-bootstrap_1.2.1_all.deb' do

--- a/recipes/uninstall.rb
+++ b/recipes/uninstall.rb
@@ -1,5 +1,6 @@
 
-package ['scalyr-agent-2', 'scalyr-repo', 'scalyr-repo-bootstrap'] do
-  action :remove
+%w[scalyr-agent-2 scalyr-repo scalyr-repo-bootstrap].each do |pkg|
+  package pkg do
+    action :remove
+  end
 end
-


### PR DESCRIPTION
Older versions of chef don't support passing array's to resources such as `apt_package`.  Iterating the array of packages makes this compatible with older versions of the chef client.