### PR TITLE
chore: Upgrade Scalyr Agent  and move package URL and files to attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,8 @@
+default['scalyr_agent']['packages']['base_url'] = 'https://www.scalyr.com/scalyr-repo/stable/latest'
+default['scalyr_agent']['packages']['deb'] = 'scalyr-repo-bootstrap_1.2.2_all.deb'
+default['scalyr_agent']['packages']['rpm'] = 'scalyr-repo-bootstrap-1.2.2-1.noarch.rpm'
+default['scalyr_agent']['packages']['rpm_alt'] = 'scalyr-repo-bootstrap-1.2.2-1.alt.noarch.rpm'
+
 default['scalyr_agent']['api_key'] = nil
 
 default['scalyr_agent']['scalyr_server'] = nil

--- a/recipes/install_deb.rb
+++ b/recipes/install_deb.rb
@@ -4,12 +4,14 @@
   end
 end
 
-remote_file '/tmp/scalyr-repo-bootstrap_1.2.1_all.deb' do
-  source 'https://www.scalyr.com/scalyr-repo/stable/latest/scalyr-repo-bootstrap_1.2.1_all.deb'
+deb_file = node['scalyr_agent']['packages']['deb']
+
+remote_file "/tmp/#{deb_file}" do
+  source "#{node['scalyr_agent']['packages']['base_url']}/#{deb_file}"
 end
 
 dpkg_package 'scalyr-repo-bootstrap' do
-  source '/tmp/scalyr-repo-bootstrap_1.2.1_all.deb'
+  source "/tmp/#{deb_file}"
   action :install
 end
 
@@ -17,4 +19,3 @@ apt_update 'update' do
   action :update
   ignore_failure true
 end
-

--- a/recipes/install_rpm.rb
+++ b/recipes/install_rpm.rb
@@ -11,17 +11,16 @@ end
 
 rpm_file =
   if node['platform_version'].to_i < 6
-    'scalyr-repo-bootstrap-1.2.1-1.alt.noarch.rpm'
+    node['scalyr_agent']['packages']['rpm']
   else
-    'scalyr-repo-bootstrap-1.2.1-1.noarch.rpm'
+    node['scalyr_agent']['packages']['rpm_alt']
   end
 
 remote_file "/tmp/#{rpm_file}" do
-  source "https://www.scalyr.com/scalyr-repo/stable/latest/#{rpm_file}"
+  source "#{node['scalyr_agent']['packages']['base_url']}/#{rpm_file}"
 end
 
 rpm_package 'scalyr-repo-bootstrap' do
   source "/tmp/#{rpm_file}"
   action :install
 end
-


### PR DESCRIPTION
After speaking with Scalyr support, it was recommended to upgrade the agent; however, I was unable to do so because the Chef cookbook hard codes an older version.

This pull request introduces new attributes so the URL and package files can be overwritten in the installation recipes. It also updates the version of Scalyr agent to the latest.